### PR TITLE
Improve error message for failed uploads

### DIFF
--- a/explore_the_world/ui/utils.py
+++ b/explore_the_world/ui/utils.py
@@ -32,7 +32,6 @@ def haystack_is_ready():
     return False
 
 
-@st.cache
 def haystack_version():
     """
     Get the Haystack version from the REST API

--- a/explore_the_world/ui/webapp.py
+++ b/explore_the_world/ui/webapp.py
@@ -94,11 +94,16 @@ Ask any question on this topic and see if Haystack can find the correct answer t
         for data_file in data_files:
             # Upload file
             if data_file:
-                raw_json = upload_doc(data_file)
-                st.sidebar.write(str(data_file.name) + " &nbsp;&nbsp; ✅ ")
-                if debug:
-                    st.subheader("REST API JSON response")
-                    st.sidebar.write(raw_json)
+                try:
+                    raw_json = upload_doc(data_file)
+                    st.sidebar.write(str(data_file.name) + " &nbsp;&nbsp; ✅ ")
+                    if debug:
+                        st.subheader("REST API JSON response")
+                        st.sidebar.write(raw_json)
+                except Exception as e:
+                    st.sidebar.write(str(data_file.name) + " &nbsp;&nbsp; ❌ ")
+                    st.sidebar.write("_This file could not be parsed, see the logs for more information._")
+                
 
     hs_version = ""
     try:


### PR DESCRIPTION
Fixes https://github.com/deepset-ai/haystack/issues/3882

Improves the error message in case of failed file uploads. This is how they look like:

![image](https://user-images.githubusercontent.com/5703634/220662020-a01b634d-8b34-47f9-b12e-b501d21afece.png)

Also remove a `@st.cache` decorator that was raising a loud deprecation warning in the interface.