### PR TITLE
add instructions for GPU support with docker

### DIFF
--- a/healthcare/README.md
+++ b/healthcare/README.md
@@ -21,6 +21,9 @@ Docker will start three containers:
 Once all the containers are up and running, you can open the user interface pointing your
 browser to [http://localhost:8501](http://localhost:8501).
 
+## Screencast
+https://user-images.githubusercontent.com/4181769/231965471-48d581a2-e1aa-4316-b3a4-990d9c86800e.mov
+
 ## Evaluation Mode
 
 The evaluation mode leverages the feedback REST API endpoint of haystack. The user has the options

--- a/healthcare/README.md
+++ b/healthcare/README.md
@@ -95,7 +95,7 @@ streamlit run ui/webapp.py
 
 ## Using GPUs with Docker
 
-Assuming you have nvidia drivers installed on your machine, you can configure docker to use the GPU for the Haystack API container to speed it up.
+Assuming you have [nvidia drivers installed](https://developer.nvidia.com/cuda-downloads) on your machine, you can configure docker to use the GPU for the Haystack API container to speed it up.
 First, configure the nvidia repository as described here: https://nvidia.github.io/nvidia-container-runtime/. For example:
 ```sh
 curl -s -L https://nvidia.github.io/nvidia-container-runtime/gpgkey | \


### PR DESCRIPTION
This PR changes the README of the healthcare demo. It adds instructions on how to let docker use a GPU and thereby drastically speed up the demo.

Further it adds a 10-seconds screencast.