### PR TITLE
update Browser Agent demo

### DIFF
--- a/browser_agent/Dockerfile
+++ b/browser_agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM deepset/hayhooks:v0.10.1
+FROM deepset/hayhooks:v1.7.0
 
 RUN pip --no-cache-dir install google-genai-haystack mcp-haystack 
 

--- a/browser_agent/docker-compose.yml
+++ b/browser_agent/docker-compose.yml
@@ -4,10 +4,8 @@ services:
     image: mcr.microsoft.com/playwright/mcp:latest
     expose: ["8931"]
     init: true
-    # This image is normally intended to be launched and controlled by a client via stdio,
-    # where the MCP server runs as a subprocess.
-    # Here we override the entrypoint to run it as a standalone MCP server, with Streamable HTTP transport.   
-    entrypoint: ["npx", "-y", "@playwright/mcp@latest", "--headless", "--browser", "chromium", "--port", "8931"]
+    entrypoint: ["node"]
+    command: ["cli.js", "--headless", "--browser", "chromium", "--no-sandbox", "--port", "8931"]
     # Check if the MCP server is listening on port 8931 using a simple TCP connection.
     # Exits 0 if the port is open (healthy), or 1 if the connection fails (unhealthy).
     # We use this syntax because other commonly used commands are not available in this image.

--- a/browser_agent/docker-compose.yml
+++ b/browser_agent/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: mcr.microsoft.com/playwright/mcp:latest
     expose: ["8931"]
     init: true
+    # See https://github.com/microsoft/playwright-mcp?tab=readme-ov-file#standalone-mcp-server (Docker section)
     entrypoint: ["node"]
     command: ["cli.js", "--headless", "--browser", "chromium", "--no-sandbox", "--port", "8931"]
     # Check if the MCP server is listening on port 8931 using a simple TCP connection.


### PR DESCRIPTION
- Use the latest version of Hayhooks
- Update Docker Compose to run the [Playwright MCP server via Docker in standalone mode](https://github.com/microsoft/playwright-mcp?tab=readme-ov-file#standalone-mcp-server). Previously, an officially supported way to do this did not exist